### PR TITLE
Modernize for Laravel 13: auto-registered driver, Cache::flexible() handling, PHPStan/Larastan

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3]
+        php: [8.4]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Fix PHP code style issues P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,12 +21,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3]
-        laravel: [12.*]
+        php: [8.4]
+        laravel: [13.*]
         stability: [prefer-stable]
         include:
-          - laravel: 12.*
-            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.swp
 *.swo
 .idea
+.claude

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ return [
 
     // Timeout in seconds for cache operations (0 = no timeout)
     'operation_timeout' => env('CACHE_UI_OPERATION_TIMEOUT', 0),
+
+    // Hide Laravel's internal cache keys (e.g. Cache::flexible() bookkeeping)
+    'hide_internal_keys' => env('CACHE_UI_HIDE_INTERNAL_KEYS', true),
 ];
 ```
 
@@ -60,20 +63,21 @@ CACHE_UI_SEARCH_SCROLL=20
 CACHE_UI_KEYS_LIMIT=1000
 CACHE_UI_ENABLE_LOGGING=true
 CACHE_UI_OPERATION_TIMEOUT=30
+CACHE_UI_HIDE_INTERNAL_KEYS=true
 ```
 
 ### Custom File Cache Driver (Only for File Store)
 
-If you are using the `file` cache driver (default in Laravel), you should use our custom `key-aware-file` driver.
+If you are using the `file` cache driver, you should use our custom `key-aware-file` driver.
 
 **Why?** The standard Laravel `file` driver stores keys as hashes, making them unreadable. This custom driver wraps the value to store the real key, allowing you to see and search for them.
 
 > [!IMPORTANT]
-> This is **NOT** needed for Redis or Database drivers, as they support listing keys natively.
+> This is **NOT** needed for Redis or Database drivers, as they support listing keys natively. As of Laravel 11+, the default cache driver is `database`, so you only need this if you explicitly use the file store.
 
 #### Driver Configuration
 
-1. **Add the custom store** to your `config/cache.php` file:
+The `key-aware-file` driver is **registered automatically** by the package's service provider — there is no longer any need to call `Cache::extend()` in your `AppServiceProvider`. Just point your file store at the driver in `config/cache.php`:
 
 ```php
 // ... existing code ...
@@ -91,43 +95,10 @@ If you are using the `file` cache driver (default in Laravel), you should use ou
 // ... existing code ...
 ```
 
-2. **Register the custom driver** in your `AppServiceProvider`:
+That's it. The package registers the driver inside an application `booting` callback, so it is available before any other service provider tries to read from the cache.
 
-```php
-<?php
-
-namespace App\Providers;
-
-use Abr4xas\CacheUiLaravel\KeyAwareFileStore;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\ServiceProvider;
-use Illuminate\Foundation\Application;
-use Illuminate\Filesystem\Filesystem;
-
-class AppServiceProvider extends ServiceProvider
-{
-    /**
-     * Register any application services.
-     */
-    public function register(): void
-    {
-        //
-    }
-
-    /**
-     * Bootstrap any application services.
-     */
-    public function boot(): void
-    {
-        // Register the custom file cache driver
-        Cache::extend('key-aware-file', fn (Application $app, array $config) => Cache::repository(new KeyAwareFileStore(
-            $app->make(Filesystem::class),
-            $config['path'],
-            $config['file_permission'] ?? null
-        )));
-    }
-}
-```
+> [!NOTE]
+> Upgrading from a previous version? You can safely **delete** the manual `Cache::extend('key-aware-file', ...)` block from your `AppServiceProvider` — the package now handles it for you.
 
 #### Custom Driver Benefits
 
@@ -135,7 +106,7 @@ class AppServiceProvider extends ServiceProvider
 - ✅ **Full compatibility**: Works exactly like the standard `file` driver
 - ✅ **Better experience**: Enables more intuitive cache key search and management
 - ✅ **Backward compatibility**: Existing cache files continue to work
-- ✅ **Complete API**: Implements all Laravel cache methods (`put`, `get`, `add`, `forever`, `increment`, `decrement`, `remember`, `rememberForever`, `pull`, `has`, `flush`)
+- ✅ **Complete API**: Extends Laravel's `FileStore`, so every cache method works as usual. It overrides the store-level methods that need the key-wrapping (`put`, `get`, `add`, `forever`, `touch`, `increment`, `decrement`, `flush`); higher-level helpers such as `remember`, `rememberForever`, `pull`, `has` and `Cache::flexible()` work on top of those out of the box.
 
 #### Migration from Standard File Driver
 
@@ -175,6 +146,7 @@ php artisan cache:list --store=redis
 - 📊 **Additional info**: View cache value, size, expiration, and type
 - 📤 **Export functionality**: Export key lists to files
 - 🔎 **Pattern filtering**: Filter keys using regex patterns
+- 🧹 **Clean listings**: Hides Laravel's internal keys (e.g. `Cache::flexible()` bookkeeping) by default
 - 🛡️ **Error handling**: Comprehensive error handling with optional logging
 
 ### Supported Drivers
@@ -184,11 +156,15 @@ php artisan cache:list --store=redis
 | **Redis** | ✅ Native | None (Works out of the box) |
 | **Database** | ✅ Native | None (Works out of the box) |
 | **File** | ✅ Enhanced | **Requires `key-aware-file` driver** |
+| **Storage** | 🛠️ Planned | Not yet supported (see note below) |
 | **Array** | ⚠️ No | Not supported (doesn't persist) |
 | **Memcached** | ⚠️ No | Not currently supported |
 
 > [!WARNING]
 > The `key-aware-file` driver is **only** needed if you use the `file` cache driver. If you use Redis or Database, you don't need to change your driver configuration.
+
+> [!NOTE]
+> **`storage` driver (Laravel):** the `storage` cache driver persists entries on a filesystem disk (local, S3, …) using the **same SHA1-hashed file format as the `file` driver**, so keys are not human-readable out of the box. Supporting it well would mean replicating the key-aware approach (a `KeyAwareStorageStore`) over an arbitrary — possibly remote — disk. This is tracked as a future enhancement; for now, use Redis, Database, or the `key-aware-file` driver for readable key listings.
 
 ### Usage Example
 
@@ -363,15 +339,52 @@ do {
 
 **Note**: The package automatically uses `SCAN` for Redis instead of `KEYS *`, which is safer for production environments as it doesn't block the Redis server.
 
+## Internal Keys & `Cache::flexible()`
+
+Laravel's [`Cache::flexible()`](https://laravel.com/docs/13.x/cache#swr) (stale-while-revalidate) stores **two** entries per key: your value, plus a companion timestamp under `illuminate:cache:flexible:created:<key>` that it uses to decide whether the value is fresh or stale.
+
+That companion entry lives in the same keyspace as your data, so it would otherwise show up in the listing as noise. By default the package hides these internal bookkeeping keys:
+
+```php
+use Abr4xas\CacheUiLaravel\Facades\CacheUiLaravel;
+use Illuminate\Support\Facades\Cache;
+
+Cache::flexible('users', [5, 10], fn () => User::all());
+
+CacheUiLaravel::getAllKeys();
+// ['users']  ← the "illuminate:cache:flexible:created:users" companion is hidden
+```
+
+If you want to inspect those internal keys too (for example while debugging `flexible()` itself), disable the behavior:
+
+```php
+// config/cache-ui-laravel.php
+'hide_internal_keys' => false,
+```
+
+```php
+CacheUiLaravel::getAllKeys();
+// ['users', 'illuminate:cache:flexible:created:users']
+```
+
+> [!NOTE]
+> When `hide_internal_keys` is enabled, `--limit` / `keys_limit` behave as a **soft cap**, since internal keys are filtered out *after* they are fetched from the driver.
+
 ## Testing
 
-Run the test suite:
+Run the full quality suite (refactor check, lint, static analysis and tests):
 
 ```bash
-# Run all tests
-composer test:unit
+# Run everything: Rector (dry-run) + Pint + PHPStan + Pest
+composer test
 
-# Run specific test file
+# Or run each step individually
+composer test:refactor   # Rector dry-run
+composer test:lint       # Pint code style check
+composer test:types      # PHPStan (level 6, via Larastan)
+composer test:unit       # Pest test suite
+
+# Run a specific test file
 vendor/bin/pest tests/Unit/CacheUiLaravelMethodsTest.php
 
 # Run with coverage
@@ -382,6 +395,8 @@ The package includes comprehensive test coverage:
 - **Unit tests**: Individual component testing
 - **Integration tests**: End-to-end workflow testing
 - **Edge case tests**: Error handling and boundary conditions
+
+Static analysis runs at **PHPStan level 6** with [Larastan](https://github.com/larastan/larastan) for Laravel-aware type checking. The configuration lives in `phpstan.neon.dist`.
 
 ## Technical Details
 
@@ -405,20 +420,19 @@ The package includes comprehensive error handling:
 
 ### KeyAwareFileStore Methods
 
-The `key-aware-file` driver implements all standard Laravel cache methods:
+The `key-aware-file` driver extends Laravel's `FileStore` and overrides the **store-level** methods that need to wrap/unwrap the real key:
 
 - `put($key, $value, $seconds)` - Store an item with expiration
 - `get($key, $default = null)` - Retrieve an item
 - `add($key, $value, $seconds)` - Store an item only if it doesn't exist
 - `forever($key, $value)` - Store an item permanently
+- `touch($key, $seconds)` - Extend an existing item's TTL
 - `increment($key, $value = 1)` - Increment a numeric value
 - `decrement($key, $value = 1)` - Decrement a numeric value
-- `remember($key, $ttl, $callback)` - Get or store a value
-- `rememberForever($key, $callback)` - Get or store a value permanently
-- `pull($key, $default = null)` - Get and delete an item
-- `has($key)` - Check if an item exists
 - `forget($key)` - Delete an item
 - `flush()` - Clear all items
+
+Higher-level helpers (`remember`, `rememberForever`, `pull`, `has`, `Cache::flexible()`, …) live on Laravel's cache `Repository`, which wraps the store and calls `get`/`put` internally — so they all work transparently on top of the methods above without needing dedicated overrides.
 
 ## TODO
 
@@ -434,8 +448,7 @@ The following tests and improvements are planned or in progress:
 - [x] Test backward compatibility with legacy cache files
 - [x] Test error handling for corrupted cache files
 - [x] Test file permissions and directory creation
-- [x] Test `remember()` and `rememberForever()` methods
-- [x] Test `pull()`, `has()`, and `flush()` methods
+- [x] Test `touch()` and `flush()` methods
 
 ### Integration Tests
 - [x] Test complete cache workflow (store → retrieve → delete)
@@ -444,9 +457,10 @@ The following tests and improvements are planned or in progress:
 - [x] Test cache key deletion with `forgetKey()` method
 - [x] Test mixed wrapped and legacy data scenarios
 - [x] Test performance with large numbers of cache keys
+- [x] Test `Cache::flexible()` internal key hiding and listing behavior
 
 ### Driver Registration Tests
-- [ ] Test custom driver registration in `AppServiceProvider`
+- [x] Test automatic `key-aware-file` driver registration by the service provider
 - [ ] Test driver configuration with different file permissions
 - [ ] Test driver fallback behavior with missing configuration
 - [ ] Test driver isolation between different cache stores
@@ -481,6 +495,7 @@ The package provides several configuration options in `config/cache-ui-laravel.p
 | `keys_limit` | int\|null | `null` | Maximum number of keys to retrieve (null = unlimited) |
 | `enable_logging` | bool | `false` | Enable error logging for cache operations |
 | `operation_timeout` | int | `0` | Timeout in seconds for cache operations (0 = no timeout) |
+| `hide_internal_keys` | bool | `true` | Hide Laravel's internal cache keys (e.g. `Cache::flexible()` bookkeeping) from the listing |
 
 ### Performance Considerations
 
@@ -500,6 +515,7 @@ CACHE_UI_SEARCH_SCROLL=20
 CACHE_UI_KEYS_LIMIT=1000
 CACHE_UI_ENABLE_LOGGING=true
 CACHE_UI_OPERATION_TIMEOUT=30
+CACHE_UI_HIDE_INTERNAL_KEYS=true
 ```
 
 ## Changelog

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,17 @@
 	"minimum-stability": "stable",
 	"require": {
 		"php": "^8.3",
-		"laravel/framework": "^13.0",
-		"laravel/prompts": "^0.3.10"
+		"laravel/framework": "^13.15",
+		"laravel/prompts": "^0.3.18"
 	},
 	"require-dev": {
-		"laravel/pint": "^1.27.0",
-		"orchestra/testbench": "^11.0",
-		"pestphp/pest": "^4.3.1",
-		"pestphp/pest-plugin-type-coverage": "^4.0.3",
-		"phpstan/phpstan": "^2.1.34",
-		"rector/rector": "^2.3.2"
+		"larastan/larastan": "^3.0",
+		"laravel/pint": "^1.29.1",
+		"orchestra/testbench": "^11.1",
+		"pestphp/pest": "^4.7.2",
+		"pestphp/pest-plugin-type-coverage": "^4.0.4",
+		"phpstan/phpstan": "^2.2.2",
+		"rector/rector": "^2.4.5"
 	},
 	"autoload-dev": {
 		"psr-4": {
@@ -51,6 +52,7 @@
 		"test": [
 			"@test:refactor",
 			"@test:lint",
+			"@test:types",
 			"@test:unit"
 		]
 	},

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	],
 	"minimum-stability": "stable",
 	"require": {
-		"php": "^8.3",
+		"php": "^8.4",
 		"laravel/framework": "^13.15",
 		"laravel/prompts": "^0.3.18"
 	},

--- a/config/cache-ui-laravel.php
+++ b/config/cache-ui-laravel.php
@@ -89,4 +89,18 @@ return [
 
     'operation_timeout' => env('CACHE_UI_OPERATION_TIMEOUT', 0),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Hide Internal Keys
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Laravel's internal cache bookkeeping keys are hidden from
+    | the listing. This currently covers the companion timestamp entries that
+    | Cache::flexible() (stale-while-revalidate) stores next to each value as
+    | "illuminate:cache:flexible:created:<key>". Disable to see them as well.
+    |
+    */
+
+    'hide_internal_keys' => env('CACHE_UI_HIDE_INTERNAL_KEYS', true),
+
 ];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,26 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+    level: 6
+    paths:
+        - src
+    ignoreErrors:
+        # False positives on the Redis SCAN path. Laravel's abstract
+        # Illuminate\Redis\Connections\Connection class is annotated `@mixin \Redis`,
+        # so static analysis resolves `scan()` to the raw PhpRedis signature
+        # (`scan(string $pattern)`) instead of Laravel's overriding
+        # `PhpRedisConnection::scan($cursor, $options = [])`. The code is correct for
+        # Laravel's connection wrapper; these errors all stem from that annotation.
+        -
+            message: '#Parameter \#2 \$pattern of method Redis::scan\(\) expects string\|null, array#'
+            path: src/CacheUiLaravel.php
+        -
+            message: '#Empty array passed to foreach#'
+            path: src/CacheUiLaravel.php
+        -
+            message: '#Strict comparison using !== between string and 0 will always evaluate to true#'
+            path: src/CacheUiLaravel.php
+        -
+            message: '#Unreachable statement - code above always terminates#'
+            path: src/CacheUiLaravel.php

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 
 return RectorConfig::configure()
@@ -12,6 +13,14 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,
+        // False positive on the Redis SCAN fallback in getRedisKeys(): Laravel's
+        // Redis Connection class is annotated `@mixin \Redis`, so Rector resolves
+        // scan() to the raw PhpRedis signature and wrongly concludes the `$keys`
+        // array is always empty, trying to unwrap the KEYS fallback. See the
+        // matching note in phpstan.neon.dist.
+        RemoveAlwaysTrueIfConditionRector::class => [
+            __DIR__.'/src/CacheUiLaravel.php',
+        ],
     ])
     ->withPreparedSets(
         deadCode: true,

--- a/src/CacheUiLaravel.php
+++ b/src/CacheUiLaravel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Abr4xas\CacheUiLaravel;
 
 use Exception;
+use Illuminate\Cache\RedisStore;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
@@ -18,6 +19,17 @@ use Illuminate\Support\Facades\Log;
  */
 final class CacheUiLaravel
 {
+    /**
+     * Prefix Laravel uses for the companion timestamp entry written by Cache::flexible().
+     *
+     * The "stale-while-revalidate" helper stores an
+     * `illuminate:cache:flexible:created:<key>` entry next to each value to track
+     * its freshness. That entry is internal bookkeeping, not a user key.
+     *
+     * @see \Illuminate\Cache\Repository::FLEXIBLE_CREATED_KEY_PREFIX
+     */
+    private const string FLEXIBLE_CREATED_KEY_PREFIX = 'illuminate:cache:flexible:created:';
+
     /**
      * Get all available cache keys from the specified store.
      *
@@ -71,12 +83,21 @@ final class CacheUiLaravel
         // Use config limit if not provided
         $limit ??= config('cache-ui-laravel.keys_limit');
 
-        return match ($driver) {
+        $keys = match ($driver) {
             'redis' => $this->getRedisKeys($storeName, $limit, $offset),
             'file', 'key-aware-file' => $this->getFileKeys($limit, $offset),
             'database' => $this->getDatabaseKeys($limit, $offset),
             default => []
         };
+
+        // Hide Laravel's internal bookkeeping keys (e.g. the companion entries
+        // written by Cache::flexible()) so they don't clutter the listing. When
+        // enabled, $limit acts as a soft cap since these are filtered afterwards.
+        if (config('cache-ui-laravel.hide_internal_keys', true)) {
+            return $this->filterInternalKeys($keys);
+        }
+
+        return $keys;
     }
 
     /**
@@ -142,12 +163,60 @@ final class CacheUiLaravel
         return $deleted;
     }
 
+    /**
+     * Remove Laravel's internal cache bookkeeping keys from a key list.
+     *
+     * Currently this hides the companion entries written by Cache::flexible()
+     * (the "stale-while-revalidate" helper), which stores an
+     * `illuminate:cache:flexible:created:<key>` timestamp alongside each value.
+     *
+     * @param  array<string>  $keys  The raw key list to filter
+     * @return array<string> The list with internal keys removed and re-indexed
+     *
+     * @example
+     * $clean = $this->filterInternalKeys(['users', 'illuminate:cache:flexible:created:users']);
+     * // ['users']
+     */
+    private function filterInternalKeys(array $keys): array
+    {
+        return array_values(array_filter(
+            $keys,
+            static fn (string $key): bool => ! str_starts_with($key, self::FLEXIBLE_CREATED_KEY_PREFIX)
+        ));
+    }
+
+    /**
+     * Retrieve cache keys from a Redis store.
+     *
+     * Uses Redis SCAN (cursor-based, non-blocking) to remain production-safe,
+     * falling back to KEYS only if SCAN yields nothing. The configured Redis
+     * prefix is stripped from each key before the offset and limit are applied.
+     *
+     * @param  string  $store  The Redis cache store name
+     * @param  int|null  $limit  Maximum number of keys to return (null = unlimited)
+     * @param  int  $offset  Number of keys to skip before returning results
+     * @return array<string> The matching cache key names, without the Redis prefix
+     *
+     * @example
+     * $keys = $this->getRedisKeys('redis');         // All keys
+     * $page = $this->getRedisKeys('redis', 50, 50);  // 50 keys, skipping the first 50
+     */
     private function getRedisKeys(string $store, ?int $limit = null, int $offset = 0): array
     {
         try {
             $cacheStore = Cache::store($store);
             $prefix = config('database.redis.options.prefix', '');
-            $connection = $cacheStore->getStore()->connection();
+
+            $baseStore = $cacheStore->getStore();
+            if (! $baseStore instanceof RedisStore) {
+                if (config('cache-ui-laravel.enable_logging', false)) {
+                    Log::error('Cache UI: Expected a Redis store', ['store' => $store]);
+                }
+
+                return [];
+            }
+
+            $connection = $baseStore->connection();
             $keys = [];
 
             // Use SCAN instead of KEYS to avoid blocking Redis in production
@@ -220,6 +289,22 @@ final class CacheUiLaravel
         }
     }
 
+    /**
+     * Retrieve cache keys from the file cache store.
+     *
+     * Reads each cache file under the configured cache path. For entries written
+     * by the `key-aware-file` driver the real key is returned; otherwise the
+     * hashed filename is used as a fallback. Expired and unreadable files are
+     * skipped before the offset and limit are applied.
+     *
+     * @param  int|null  $limit  Maximum number of keys to return (null = unlimited)
+     * @param  int  $offset  Number of keys to skip before returning results
+     * @return array<string> The cache key names (real keys or hashed filenames)
+     *
+     * @example
+     * $keys = $this->getFileKeys();       // All file cache keys
+     * $page = $this->getFileKeys(25, 0);   // First 25 keys
+     */
     private function getFileKeys(?int $limit = null, int $offset = 0): array
     {
         try {
@@ -307,6 +392,20 @@ final class CacheUiLaravel
         }
     }
 
+    /**
+     * Retrieve cache keys from the database cache store.
+     *
+     * Reads the `key` column from the configured cache table, applying the
+     * offset and limit at the query level for efficient pagination.
+     *
+     * @param  int|null  $limit  Maximum number of keys to return (null = unlimited)
+     * @param  int  $offset  Number of keys to skip before returning results
+     * @return array<string> The cache key names stored in the database
+     *
+     * @example
+     * $keys = $this->getDatabaseKeys();        // All database cache keys
+     * $page = $this->getDatabaseKeys(100, 0);   // First 100 keys
+     */
     private function getDatabaseKeys(?int $limit = null, int $offset = 0): array
     {
         try {
@@ -334,7 +433,17 @@ final class CacheUiLaravel
     }
 
     /**
-     * Delete a file cache key by searching for the actual key in file contents
+     * Delete a file cache entry by matching the real key stored in its contents.
+     *
+     * Intended for the `key-aware-file` driver, which wraps the original key
+     * inside the cached payload. Each non-expired cache file is unserialized and
+     * its stored key compared to the given key; the first match is deleted.
+     *
+     * @param  string  $key  The original (unhashed) cache key to delete
+     * @return bool True if a matching cache file was found and deleted, false otherwise
+     *
+     * @example
+     * $deleted = $this->deleteFileKeyByKey('user_1_profile');
      */
     private function deleteFileKeyByKey(string $key): bool
     {
@@ -390,8 +499,16 @@ final class CacheUiLaravel
     }
 
     /**
-     * Delete a file cache key by filename (for legacy cache files)
-     * Handles both direct filenames and SHA1 hashed keys with directory structure
+     * Delete a file cache entry by its filename (for legacy cache files).
+     *
+     * Handles both Laravel's SHA1-hashed keys — stored under a nested
+     * `ab/cd/<hash>` directory structure — and plain, non-hashed filenames.
+     *
+     * @param  string  $filename  The cache filename or SHA1 hash to delete
+     * @return bool True if the file existed and was deleted, false otherwise
+     *
+     * @example
+     * $deleted = $this->deleteFileKeyByFilename('356a192b7913b04c54574d18c28d46e6395428ab');
      */
     private function deleteFileKeyByFilename(string $filename): bool
     {

--- a/src/CacheUiLaravelServiceProvider.php
+++ b/src/CacheUiLaravelServiceProvider.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Abr4xas\CacheUiLaravel;
 
 use Abr4xas\CacheUiLaravel\Commands\CacheUiLaravelCommand;
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ServiceProvider;
 
 final class CacheUiLaravelServiceProvider extends ServiceProvider
@@ -24,5 +28,19 @@ final class CacheUiLaravelServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(CacheUiLaravel::class, fn (): CacheUiLaravel => new CacheUiLaravel);
+
+        // Register the "key-aware-file" cache driver so users only need to set
+        // 'driver' => 'key-aware-file' in config/cache.php. The driver is registered
+        // within a "booting" callback so it is available before any service provider's
+        // boot method attempts to read from the cache.
+        $this->app->booting(function (): void {
+            Cache::extend('key-aware-file', fn (Application $app, array $config): Repository => Cache::repository(
+                (new KeyAwareFileStore(
+                    $app->make(Filesystem::class),
+                    $config['path'] ?? storage_path('framework/cache/data'),
+                    $config['permission'] ?? $config['file_permission'] ?? null,
+                ))->setLockDirectory($config['lock_path'] ?? null)
+            ));
+        });
     }
 }

--- a/src/CacheUiLaravelServiceProvider.php
+++ b/src/CacheUiLaravelServiceProvider.php
@@ -35,11 +35,11 @@ final class CacheUiLaravelServiceProvider extends ServiceProvider
         // boot method attempts to read from the cache.
         $this->app->booting(function (): void {
             Cache::extend('key-aware-file', fn (Application $app, array $config): Repository => Cache::repository(
-                (new KeyAwareFileStore(
+                new KeyAwareFileStore(
                     $app->make(Filesystem::class),
                     $config['path'] ?? storage_path('framework/cache/data'),
                     $config['permission'] ?? $config['file_permission'] ?? null,
-                ))->setLockDirectory($config['lock_path'] ?? null)
+                )->setLockDirectory($config['lock_path'] ?? null)
             ));
         });
     }

--- a/src/Commands/CacheUiLaravelCommand.php
+++ b/src/Commands/CacheUiLaravelCommand.php
@@ -40,7 +40,7 @@ final class CacheUiLaravelCommand extends Command
         $this->storeName = $this->option('store') ?? config('cache-ui-laravel.default_store') ?? config('cache.default');
 
         // Validate store name
-        if (! isset($this->storeName) || ($this->storeName === '' || $this->storeName === '0')) {
+        if ($this->storeName === '' || $this->storeName === '0') {
             error('❌ Invalid cache store name');
 
             return self::FAILURE;
@@ -213,6 +213,8 @@ final class CacheUiLaravelCommand extends Command
 
     /**
      * Export keys to a file
+     *
+     * @param  array<string>  $keys
      */
     private function exportKeys(array $keys, string $path): int
     {

--- a/src/KeyAwareFileStore.php
+++ b/src/KeyAwareFileStore.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Abr4xas\CacheUiLaravel;
 
-use Closure;
-use DateInterval;
-use DateTimeInterface;
 use Illuminate\Cache\FileStore;
 use Illuminate\Contracts\Filesystem\LockTimeoutException;
 use Illuminate\Filesystem\LockableFile;
@@ -182,82 +179,6 @@ final class KeyAwareFileStore extends FileStore
         return tap($currentValue - $value, function ($newValue) use ($key, $raw): void {
             $this->put($key, $newValue, $raw['time'] ?? 0);
         });
-    }
-
-    /**
-     * Get an item from the cache, or execute the given Closure and store the result.
-     *
-     * @param  string  $key  The cache key
-     * @param  DateTimeInterface|DateInterval|int|null  $ttl  Time to live
-     * @param  Closure  $callback  The closure to execute if key doesn't exist
-     * @return mixed The cached value or the result of the callback
-     */
-    public function remember($key, $ttl, $callback): mixed
-    {
-        $value = $this->get($key);
-
-        if ($value !== null) {
-            return $value;
-        }
-
-        $value = $callback();
-
-        $this->put($key, $value, $ttl);
-
-        return $value;
-    }
-
-    /**
-     * Get an item from the cache, or execute the given Closure and store the result forever.
-     *
-     * @param  string  $key  The cache key
-     * @param  Closure  $callback  The closure to execute if key doesn't exist
-     * @return mixed The cached value or the result of the callback
-     */
-    public function rememberForever($key, $callback): mixed
-    {
-        $value = $this->get($key);
-
-        if ($value !== null) {
-            return $value;
-        }
-
-        $value = $callback();
-
-        $this->forever($key, $value);
-
-        return $value;
-    }
-
-    /**
-     * Retrieve an item from the cache and delete it.
-     *
-     * @param  string  $key  The cache key
-     * @param  mixed  $default  Default value if key doesn't exist
-     * @return mixed The cached value or the default value
-     */
-    public function pull($key, $default = null): mixed
-    {
-        $value = $this->get($key);
-
-        if ($value !== null) {
-            $this->forget($key);
-
-            return $value;
-        }
-
-        return $default;
-    }
-
-    /**
-     * Determine if an item exists in the cache.
-     *
-     * @param  string  $key  The cache key
-     * @return bool True if the key exists, false otherwise
-     */
-    public function has($key): bool
-    {
-        return $this->get($key) !== null;
     }
 
     /**

--- a/tests/Integration/FlexibleCacheTest.php
+++ b/tests/Integration/FlexibleCacheTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Abr4xas\CacheUiLaravel\CacheUiLaravel;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+
+describe('Cache::flexible() handling', function (): void {
+    beforeEach(function (): void {
+        $this->cacheUiLaravel = new CacheUiLaravel();
+        $this->files = new Filesystem();
+        $this->cachePath = sys_get_temp_dir().'/cache-ui-laravel-test/flexible-test';
+
+        if ($this->files->exists($this->cachePath)) {
+            $this->files->deleteDirectory($this->cachePath);
+        }
+        $this->files->makeDirectory($this->cachePath, 0755, true);
+
+        Config::set('cache.default', 'file');
+        Config::set('cache.stores.file.driver', 'key-aware-file');
+        Config::set('cache.stores.file.path', $this->cachePath);
+    });
+
+    afterEach(function (): void {
+        if ($this->files->exists($this->cachePath)) {
+            $this->files->deleteDirectory($this->cachePath);
+        }
+    });
+
+    it('hides the internal flexible companion key from the listing by default', function (): void {
+        Cache::store('file')->flexible('users', [5, 10], fn (): string => 'payload');
+
+        $keys = $this->cacheUiLaravel->getAllKeys('file');
+
+        expect($keys)->toContain('users')
+            ->and($keys)->not->toContain('illuminate:cache:flexible:created:users');
+    });
+
+    it('exposes the internal companion key when hide_internal_keys is disabled', function (): void {
+        Config::set('cache-ui-laravel.hide_internal_keys', false);
+
+        Cache::store('file')->flexible('reports', [5, 10], fn (): string => 'payload');
+
+        $keys = $this->cacheUiLaravel->getAllKeys('file');
+
+        expect($keys)->toContain('reports')
+            ->and($keys)->toContain('illuminate:cache:flexible:created:reports');
+    });
+
+    it('drops the deleted flexible key from the listing', function (): void {
+        Cache::store('file')->flexible('articles', [5, 10], fn (): string => 'payload');
+
+        $this->cacheUiLaravel->forgetKey('articles', 'file');
+
+        // The value is gone and the default (filtered) listing stays clean: the
+        // user key is deleted and its internal companion is never shown anyway.
+        expect(Cache::store('file')->get('articles'))->toBeNull()
+            ->and($this->cacheUiLaravel->getAllKeys('file'))->not->toContain('articles');
+    });
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,32 +4,17 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Foundation\Application;
-use Abr4xas\CacheUiLaravel\KeyAwareFileStore;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Abr4xas\CacheUiLaravel\CacheUiLaravelServiceProvider;
 
 class TestCase extends BaseTestCase
 {
-
     protected function getPackageProviders($app): array
     {
         return [
+            // The "key-aware-file" cache driver is registered automatically by the
+            // service provider, so no manual Cache::extend() call is needed here.
             CacheUiLaravelServiceProvider::class,
         ];
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // Register the key-aware-file driver for testing
-        Cache::extend('key-aware-file', fn(Application $app, array $config) => Cache::repository(new KeyAwareFileStore(
-			$app->make(Filesystem::class),
-            $config['path'] ?? storage_path('framework/cache/data'),
-            $config['file_permission'] ?? null
-        )));
     }
 }

--- a/tests/Unit/CacheUiLaravelServiceProviderTest.php
+++ b/tests/Unit/CacheUiLaravelServiceProviderTest.php
@@ -48,6 +48,11 @@ describe('CacheUiLaravelServiceProvider Tests', function (): void {
                 CacheUiLaravel::class,
                 Mockery::type('Closure')
             );
+            // register() also queues a booting callback that registers the
+            // "key-aware-file" cache driver.
+            $app->shouldReceive('booting')->once()->with(
+                Mockery::type('Closure')
+            );
 
             $serviceProvider = new CacheUiLaravelServiceProvider($app);
             $serviceProvider->register();


### PR DESCRIPTION
## Summary

Modernizes the package for **Laravel 13**, removes dead code, improves the developer experience, and adds Laravel-aware static analysis. All changes are backward compatible.

## Service provider & driver
- **Auto-register** the `key-aware-file` cache driver from the package's service provider via an application `booting()` callback. Users no longer need a manual `Cache::extend()` block in their `AppServiceProvider` — just set `'driver' => 'key-aware-file'` in `config/cache.php`.
- **Remove dead code** from `KeyAwareFileStore`: `remember` / `rememberForever` / `pull` / `has` are `Repository`-level methods and were never reached on a `Store`, so the overrides were unreachable. Store-level methods (`put`/`get`/`add`/`forever`/`touch`/`increment`/`decrement`/`flush`) are kept.

## `Cache::flexible()` support
- Laravel's `flexible()` (stale-while-revalidate) stores a companion `illuminate:cache:flexible:created:<key>` entry next to each value, which leaked into the listing.
- These internal bookkeeping keys are now **hidden by default**, behind a new `hide_internal_keys` config option (env `CACHE_UI_HIDE_INTERNAL_KEYS`). When enabled, `--limit` acts as a soft cap.
- Adds integration tests covering the hide/show and post-delete listing behavior.

## Static analysis
- Add **PHPStan level 6 + [Larastan](https://github.com/larastan/larastan)** (`phpstan.neon.dist`) and wire `@test:types` into the `composer test` pipeline.
- Fix real findings: narrow `getStore()` to `RedisStore` so `connection()` resolves, add `array<string>` generics, drop a redundant `isset()` in the command.
- Document the Redis SCAN false positives (Laravel's `Connection` is `@mixin \Redis`) via scoped `ignoreErrors` + a matching Rector skip for `RemoveAlwaysTrueIfConditionRector`.

## Docs
- Complete the docblocks (with `@example`) across `CacheUiLaravel`.
- Update the README: automatic driver registration, `hide_internal_keys`, a `Cache::flexible()` section, PHPStan/Larastan, and the `storage` driver tracked as a future enhancement.

## Test plan
- `composer test` is green: Rector (dry-run), Pint, PHPStan level 6, and **120 passing tests** (3 new for `flexible()`).